### PR TITLE
♻️ Change printWidth to 128

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,7 +7,7 @@
       "files": "*.sol",
       "options": {
         "tabWidth": 4,
-        "printWidth": 120
+        "printWidth": 128
       }
     }
   ]


### PR DESCRIPTION
Github allows 140 character widths and etherscan shows 233 characters when displaying verified contracts.

This pr changes the prettier enforced page width from 120 to the vastly superior number 128.

requisite cute baby animal pic:
![cute-baby-animals-13](https://user-images.githubusercontent.com/71567643/169962686-9c2ff8bd-963e-4c29-8151-0ad625d58f45.jpeg)
